### PR TITLE
Feature/add migrated services

### DIFF
--- a/.github/backend-cd.exclusions.json
+++ b/.github/backend-cd.exclusions.json
@@ -1,7 +1,3 @@
 {
-  "exclude": [
-    "notification",
-    "partner-management",
-    "pms-integration"
-  ]
+  "exclude": []
 }

--- a/.github/workflows/backend-cd-prod.yml
+++ b/.github/workflows/backend-cd-prod.yml
@@ -25,6 +25,9 @@ env:
   CATALOG_DB_SECRET_NAME_DEV: travelhub/dev/catalog/db-credentials
   PAYMENT_DB_SECRET_NAME_DEV: travelhub/dev/payment/db-credentials
   PAYMENT_APP_SECRET_NAME_DEV: travelhub/dev/payment/app-secrets
+  PMS_INTEGRATION_DB_SECRET_NAME_DEV: travelhub/dev/pms-integration/db-credentials
+  PARTNER_MANAGEMENT_DB_SECRET_NAME_DEV: travelhub/dev/partner-management/db-credentials
+  NOTIFICATION_DB_SECRET_NAME_DEV: travelhub/dev/notification/db-credentials
   SEARCH_DB_SECRET_NAME_DEV: travelhub/dev/search/db-credentials
   SERVICE_EXCLUSIONS_FILE: .github/backend-cd.exclusions.json
 
@@ -157,6 +160,8 @@ jobs:
                   service["deployment_manifest"],
                   service["service_manifest"],
               ]
+              if service["service_name"] == "booking":
+                  watch_paths.append("Infraestructura/k8s/aws/booking-saga-worker-deployment.yaml")
               if any(
                   changed.startswith(prefix)
                   for changed in changed_files
@@ -188,6 +193,8 @@ jobs:
       DEPLOYMENT_MANIFEST: ${{ matrix.deployment_manifest }}
       SERVICE_MANIFEST: ${{ matrix.service_manifest }}
       RENDERED_DEPLOYMENT_MANIFEST: /tmp/${{ matrix.service_name }}-deployment.rendered.yaml
+      SAGA_WORKER_DEPLOYMENT_MANIFEST: Infraestructura/k8s/aws/booking-saga-worker-deployment.yaml
+      RENDERED_SAGA_WORKER_DEPLOYMENT_MANIFEST: /tmp/booking-saga-worker-deployment.rendered.yaml
       SERVICE_NAME: ${{ matrix.service_name }}
       ECR_REPOSITORY: ${{ matrix.ecr_repository }}
       HEALTHCHECK_PATH: /health
@@ -214,6 +221,11 @@ jobs:
 
           if [ ! -f "${SERVICE_MANIFEST}" ]; then
             echo "::error file=${SERVICE_MANIFEST}::Missing Kubernetes Service manifest. Expected file '${SERVICE_MANIFEST}' was not found."
+            exit 1
+          fi
+
+          if [ "${SERVICE_NAME}" = "booking" ] && [ ! -f "${SAGA_WORKER_DEPLOYMENT_MANIFEST}" ]; then
+            echo "::error file=${SAGA_WORKER_DEPLOYMENT_MANIFEST}::Missing booking saga worker deployment manifest."
             exit 1
           fi
 
@@ -432,7 +444,7 @@ jobs:
           fi
 
       - name: Reconcile service DB secret
-        if: ${{ matrix.service_name == 'authservice' || matrix.service_name == 'booking' || matrix.service_name == 'catalog' || matrix.service_name == 'payment' || matrix.service_name == 'search' }}
+        if: ${{ matrix.service_name == 'authservice' || matrix.service_name == 'booking' || matrix.service_name == 'catalog' || matrix.service_name == 'payment' || matrix.service_name == 'pms-integration' || matrix.service_name == 'partner-management' || matrix.service_name == 'notification' || matrix.service_name == 'search' }}
         shell: bash
         env:
           DB_SECRET_ENV_FILE: /tmp/${{ matrix.service_name }}-db-secret.env
@@ -455,6 +467,18 @@ jobs:
             payment)
               SECRET_MANAGER_ID="${PAYMENT_DB_SECRET_NAME_DEV}"
               K8S_SECRET_NAME="payment-db-secret"
+              ;;
+            pms-integration)
+              SECRET_MANAGER_ID="${PMS_INTEGRATION_DB_SECRET_NAME_DEV}"
+              K8S_SECRET_NAME="pms-integration-db-secret"
+              ;;
+            partner-management)
+              SECRET_MANAGER_ID="${PARTNER_MANAGEMENT_DB_SECRET_NAME_DEV}"
+              K8S_SECRET_NAME="partner-management-db-secret"
+              ;;
+            notification)
+              SECRET_MANAGER_ID="${NOTIFICATION_DB_SECRET_NAME_DEV}"
+              K8S_SECRET_NAME="notification-db-secret"
               ;;
             search)
               SECRET_MANAGER_ID="${SEARCH_DB_SECRET_NAME_DEV}"
@@ -566,6 +590,39 @@ jobs:
           kubectl apply -n "${K8S_NAMESPACE_DEV}" -f "${SERVICE_MANIFEST}"
           kubectl apply -n "${K8S_NAMESPACE_DEV}" -f "${RENDERED_DEPLOYMENT_MANIFEST}"
 
+      - name: Apply booking saga worker manifest
+        if: ${{ matrix.service_name == 'booking' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import os
+          import sys
+
+          src = os.environ["SAGA_WORKER_DEPLOYMENT_MANIFEST"]
+          dst = os.environ["RENDERED_SAGA_WORKER_DEPLOYMENT_MANIFEST"]
+          registry = os.environ.get("ECR_REGISTRY_DEV", "")
+          sha = os.environ.get("GITHUB_SHA", "")
+
+          try:
+              with open(src, "r", encoding="utf-8") as f:
+                  content = f.read()
+          except Exception as exc:
+              print(f"::error file={src}::Failed to read saga worker manifest: {exc}")
+              sys.exit(1)
+
+          rendered = content.replace("${ECR_REGISTRY_DEV}", registry)
+          rendered = rendered.replace("${GITHUB_SHA}", sha)
+
+          if "${ECR_REGISTRY_DEV}" in rendered or "${GITHUB_SHA}" in rendered:
+              print("::error::Saga worker manifest still contains unresolved placeholders after rendering.")
+              sys.exit(1)
+
+          with open(dst, "w", encoding="utf-8") as f:
+              f.write(rendered)
+          PY
+          kubectl apply -n "${K8S_NAMESPACE_DEV}" -f "${RENDERED_SAGA_WORKER_DEPLOYMENT_MANIFEST}"
+
       - name: Wait for rollout
         shell: bash
         run: |
@@ -573,6 +630,12 @@ jobs:
           kubectl rollout status "deployment/${SERVICE_NAME}" \
             --namespace "${K8S_NAMESPACE_DEV}" \
             --timeout=300s
+
+          if [ "${SERVICE_NAME}" = "booking" ]; then
+            kubectl rollout status "deployment/booking-saga-worker" \
+              --namespace "${K8S_NAMESPACE_DEV}" \
+              --timeout=300s
+          fi
 
       - name: Verify service response (port-forward)
         shell: bash

--- a/.github/workflows/infra-cd-base.yml
+++ b/.github/workflows/infra-cd-base.yml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - 'Infraestructura/terraform/**'
+      - 'Infraestructura/k8s/aws/*-deployment.yaml'
       - 'Infraestructura/k8s/aws/*-service.yaml'
       - 'Infraestructura/k8s/aws/backend-ingress.yaml'
       - 'Infraestructura/k8s/aws/authservice-ingress.yaml'

--- a/.github/workflows/infra-cd-prod.yml
+++ b/.github/workflows/infra-cd-prod.yml
@@ -223,6 +223,14 @@ jobs:
             kubectl create namespace "${K8S_NAMESPACE_DEV}"
           fi
 
+      - name: Apply backend infrastructure manifests
+        run: |
+          set -euo pipefail
+          kubectl apply -n "${K8S_NAMESPACE_DEV}" -f ../../../k8s/aws/rabbitmq-broker-deployment.yaml
+          kubectl apply -n "${K8S_NAMESPACE_DEV}" -f ../../../k8s/aws/rabbitmq-broker-service.yaml
+          kubectl apply -n "${K8S_NAMESPACE_DEV}" -f ../../../k8s/aws/redis-db-deployment.yaml
+          kubectl apply -n "${K8S_NAMESPACE_DEV}" -f ../../../k8s/aws/redis-db-service.yaml
+
       - name: Apply backend service manifests
         run: |
           set -euo pipefail
@@ -231,8 +239,8 @@ jobs:
           kubectl apply -n "${K8S_NAMESPACE_DEV}" -f ../../../k8s/aws/catalog-service.yaml
           kubectl apply -n "${K8S_NAMESPACE_DEV}" -f ../../../k8s/aws/notification-service.yaml
           kubectl apply -n "${K8S_NAMESPACE_DEV}" -f ../../../k8s/aws/payment-service.yaml
-          kubectl apply -n "${K8S_NAMESPACE_DEV}" -f ../../../k8s/aws/partnermanagement-service.yaml
-          kubectl apply -n "${K8S_NAMESPACE_DEV}" -f ../../../k8s/aws/pmsintegration-service.yaml
+          kubectl apply -n "${K8S_NAMESPACE_DEV}" -f ../../../k8s/aws/partner-management-service.yaml
+          kubectl apply -n "${K8S_NAMESPACE_DEV}" -f ../../../k8s/aws/pms-integration-service.yaml
           kubectl apply -n "${K8S_NAMESPACE_DEV}" -f ../../../k8s/aws/search-service.yaml
 
       - name: Apply ingress manifests

--- a/Infraestructura/k8s/aws/backend-ingress.yaml
+++ b/Infraestructura/k8s/aws/backend-ingress.yaml
@@ -22,7 +22,7 @@ spec:
         pathType: ImplementationSpecific
         backend:
           service:
-            name: notification-service
+            name: notification
             port:
               number: 80
 
@@ -38,7 +38,7 @@ spec:
         pathType: ImplementationSpecific
         backend:
           service:
-            name: pmsintegration-service
+            name: pms-integration
             port:
               number: 80
 
@@ -46,7 +46,7 @@ spec:
         pathType: ImplementationSpecific
         backend:
           service:
-            name: partnermanagement-service
+            name: partner-management
             port:
               number: 80
 

--- a/Infraestructura/k8s/aws/booking-deployment.yaml
+++ b/Infraestructura/k8s/aws/booking-deployment.yaml
@@ -20,6 +20,22 @@ spec:
           ports:
             - containerPort: 8000
           env:
+          - name: BOOKING_DB_MODE
+            value: postgres
+          - name: CATALOG_SERVICE_URL
+            value: http://catalog/catalog
+          - name: PAYMENT_SERVICE_URL
+            value: http://payment
+          - name: PAYMENT_MODE
+            value: wompi
+          - name: RABBITMQ_HOST
+            value: rabbitmq-broker
+          - name: RABBITMQ_PORT
+            value: "5672"
+          - name: RABBITMQ_USER
+            value: guest
+          - name: RABBITMQ_PASS
+            value: guest
           - name: DB_HOST
             valueFrom:
               secretKeyRef:

--- a/Infraestructura/k8s/aws/booking-saga-worker-deployment.yaml
+++ b/Infraestructura/k8s/aws/booking-saga-worker-deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: booking-saga-worker
+  labels:
+    app: booking-saga-worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: booking-saga-worker
+  template:
+    metadata:
+      labels:
+        app: booking-saga-worker
+    spec:
+      containers:
+        - name: booking-saga-worker
+          image: ${ECR_REGISTRY_DEV}/booking:${GITHUB_SHA}
+          command: ["python", "/src/Booking/modulos/saga_reservas/infraestructura/consumidor_evt_saga.py"]
+          env:
+            - name: REDIS_HOST
+              value: redis-db
+            - name: RABBITMQ_HOST
+              value: rabbitmq-broker
+            - name: RABBITMQ_PORT
+              value: "5672"
+            - name: RABBITMQ_USER
+              value: guest
+            - name: RABBITMQ_PASS
+              value: guest
+            - name: PYTHONPATH
+              value: /src
+            - name: PYTHONUNBUFFERED
+              value: "1"
+            - name: BOOKING_DB_MODE
+              value: postgres
+            - name: BOOKING_INSTANCE_PATH
+              value: /src/instance
+            - name: PAYMENT_MODE
+              value: wompi
+            - name: PAYMENT_SERVICE_URL
+              value: http://payment
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: booking-db-secret
+                  key: DB_HOST
+            - name: DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: booking-db-secret
+                  key: DB_PORT
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: booking-db-secret
+                  key: DB_NAME
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: booking-db-secret
+                  key: DB_USER
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: booking-db-secret
+                  key: DB_PASSWORD

--- a/Infraestructura/k8s/aws/notification-deployment.yaml
+++ b/Infraestructura/k8s/aws/notification-deployment.yaml
@@ -20,6 +20,31 @@ spec:
           ports:
             - containerPort: 8000
           env:
+            - name: NOTIFICATION_DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: notification-db-secret
+                  key: DB_HOST
+            - name: NOTIFICATION_DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: notification-db-secret
+                  key: DB_PORT
+            - name: NOTIFICATION_DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: notification-db-secret
+                  key: DB_NAME
+            - name: NOTIFICATION_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: notification-db-secret
+                  key: DB_USER
+            - name: NOTIFICATION_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: notification-db-secret
+                  key: DB_PASSWORD
             - name: RABBITMQ_HOST
               value: rabbitmq-broker
             - name: RABBITMQ_PORT

--- a/Infraestructura/k8s/aws/partner-management-deployment.yaml
+++ b/Infraestructura/k8s/aws/partner-management-deployment.yaml
@@ -20,6 +20,31 @@ spec:
           ports:
             - containerPort: 8000
           env:
+            - name: PARTNER_DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: partner-management-db-secret
+                  key: DB_HOST
+            - name: PARTNER_DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: partner-management-db-secret
+                  key: DB_PORT
+            - name: PARTNER_DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: partner-management-db-secret
+                  key: DB_NAME
+            - name: PARTNER_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: partner-management-db-secret
+                  key: DB_USER
+            - name: PARTNER_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: partner-management-db-secret
+                  key: DB_PASSWORD
             - name: RABBITMQ_HOST
               value: rabbitmq-broker
             - name: RABBITMQ_PORT

--- a/Infraestructura/k8s/aws/partner-management-deployment.yaml
+++ b/Infraestructura/k8s/aws/partner-management-deployment.yaml
@@ -1,22 +1,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: notification
+  name: partner-management
   labels:
-    app: notification
+    app: partner-management
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: notification
+      app: partner-management
   template:
     metadata:
       labels:
-        app: notification
+        app: partner-management
     spec:
       containers:
-        - name: notification
-          image: ${ECR_REGISTRY_DEV}/notification:${GITHUB_SHA}
+        - name: partner-management
+          image: ${ECR_REGISTRY_DEV}/partner-management:${GITHUB_SHA}
           ports:
             - containerPort: 8000
           env:
@@ -28,8 +28,6 @@ spec:
               value: guest
             - name: RABBITMQ_PASS
               value: guest
-            - name: REDIS_HOST
-              value: redis-db
           startupProbe:
             httpGet:
               path: /health

--- a/Infraestructura/k8s/aws/partner-management-service.yaml
+++ b/Infraestructura/k8s/aws/partner-management-service.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: notification
+  name: partner-management
 spec:
   type: ClusterIP
   selector:
-    app: notification
+    app: partner-management
   ports:
     - protocol: TCP
       port: 80

--- a/Infraestructura/k8s/aws/pms-integration-deployment.yaml
+++ b/Infraestructura/k8s/aws/pms-integration-deployment.yaml
@@ -20,6 +20,31 @@ spec:
           ports:
             - containerPort: 8001
           env:
+            - name: PMS_DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: pms-integration-db-secret
+                  key: DB_HOST
+            - name: PMS_DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: pms-integration-db-secret
+                  key: DB_PORT
+            - name: PMS_DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: pms-integration-db-secret
+                  key: DB_NAME
+            - name: PMS_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: pms-integration-db-secret
+                  key: DB_USER
+            - name: PMS_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: pms-integration-db-secret
+                  key: DB_PASSWORD
             - name: RABBITMQ_HOST
               value: rabbitmq-broker
             - name: RABBITMQ_PORT

--- a/Infraestructura/k8s/aws/pms-integration-deployment.yaml
+++ b/Infraestructura/k8s/aws/pms-integration-deployment.yaml
@@ -1,24 +1,24 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: notification
+  name: pms-integration
   labels:
-    app: notification
+    app: pms-integration
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: notification
+      app: pms-integration
   template:
     metadata:
       labels:
-        app: notification
+        app: pms-integration
     spec:
       containers:
-        - name: notification
-          image: ${ECR_REGISTRY_DEV}/notification:${GITHUB_SHA}
+        - name: pms-integration
+          image: ${ECR_REGISTRY_DEV}/pms-integration:${GITHUB_SHA}
           ports:
-            - containerPort: 8000
+            - containerPort: 8001
           env:
             - name: RABBITMQ_HOST
               value: rabbitmq-broker
@@ -28,23 +28,21 @@ spec:
               value: guest
             - name: RABBITMQ_PASS
               value: guest
-            - name: REDIS_HOST
-              value: redis-db
           startupProbe:
             httpGet:
               path: /health
-              port: 8000
+              port: 8001
             periodSeconds: 5
             failureThreshold: 24
           readinessProbe:
             httpGet:
               path: /health
-              port: 8000
+              port: 8001
             initialDelaySeconds: 5
             periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /health
-              port: 8000
+              port: 8001
             initialDelaySeconds: 10
             periodSeconds: 10

--- a/Infraestructura/k8s/aws/pms-integration-service.yaml
+++ b/Infraestructura/k8s/aws/pms-integration-service.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: notification
+  name: pms-integration
 spec:
   type: ClusterIP
   selector:
-    app: notification
+    app: pms-integration
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 8000
+      targetPort: 8001

--- a/Infraestructura/k8s/aws/rabbitmq-broker-deployment.yaml
+++ b/Infraestructura/k8s/aws/rabbitmq-broker-deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rabbitmq-broker
+  labels:
+    app: rabbitmq-broker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rabbitmq-broker
+  template:
+    metadata:
+      labels:
+        app: rabbitmq-broker
+    spec:
+      containers:
+        - name: rabbitmq-broker
+          image: rabbitmq:3.13-management-alpine
+          ports:
+            - containerPort: 5672
+            - containerPort: 15672
+          env:
+            - name: RABBITMQ_DEFAULT_USER
+              value: guest
+            - name: RABBITMQ_DEFAULT_PASS
+              value: guest
+          readinessProbe:
+            exec:
+              command:
+                - rabbitmq-diagnostics
+                - -q
+                - ping
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command:
+                - rabbitmq-diagnostics
+                - -q
+                - ping
+            initialDelaySeconds: 20
+            periodSeconds: 20

--- a/Infraestructura/k8s/aws/rabbitmq-broker-service.yaml
+++ b/Infraestructura/k8s/aws/rabbitmq-broker-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rabbitmq-broker
+spec:
+  type: ClusterIP
+  selector:
+    app: rabbitmq-broker
+  ports:
+    - name: amqp
+      protocol: TCP
+      port: 5672
+      targetPort: 5672
+    - name: management
+      protocol: TCP
+      port: 15672
+      targetPort: 15672

--- a/Infraestructura/k8s/aws/redis-db-deployment.yaml
+++ b/Infraestructura/k8s/aws/redis-db-deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-db
+  labels:
+    app: redis-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis-db
+  template:
+    metadata:
+      labels:
+        app: redis-db
+    spec:
+      containers:
+        - name: redis-db
+          image: redis:7-alpine
+          ports:
+            - containerPort: 6379
+          readinessProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 10
+            periodSeconds: 20

--- a/Infraestructura/k8s/aws/redis-db-service.yaml
+++ b/Infraestructura/k8s/aws/redis-db-service.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: notification
+  name: redis-db
 spec:
   type: ClusterIP
   selector:
-    app: notification
+    app: redis-db
   ports:
     - protocol: TCP
-      port: 80
-      targetPort: 8000
+      port: 6379
+      targetPort: 6379

--- a/Infraestructura/terraform/environments/dev/container_registry/dev.tfvars
+++ b/Infraestructura/terraform/environments/dev/container_registry/dev.tfvars
@@ -15,7 +15,7 @@ owner = "grupo12"
 
 # Required by Terraform.
 # The backend CD pipeline supports exactly these repositories in dev.
-repository_names = ["authservice", "search", "booking", "catalog", "payment"]
+repository_names = ["authservice", "search", "booking", "catalog", "payment", "pms-integration", "partner-management", "notification"]
 
 # Added to avoid hidden defaults.
 # The stack has a default of 5, but dev should set retention explicitly to control storage cost.

--- a/Infraestructura/terraform/environments/dev/database/terraform.tfvars
+++ b/Infraestructura/terraform/environments/dev/database/terraform.tfvars
@@ -34,6 +34,21 @@ service_databases = {
     db_name     = "payment_db"
     db_username = "payment_app"
   }
+  "pms-integration" = {
+    secret_name = "travelhub/dev/pms-integration/db-credentials"
+    db_name     = "pms_integration_db"
+    db_username = "pms_integration_app"
+  }
+  "partner-management" = {
+    secret_name = "travelhub/dev/partner-management/db-credentials"
+    db_name     = "partner_management_db"
+    db_username = "partner_management_app"
+  }
+  notification = {
+    secret_name = "travelhub/dev/notification/db-credentials"
+    db_name     = "notification_db"
+    db_username = "notification_app"
+  }
   search = {
     secret_name     = "travelhub/dev/search/db-credentials"
     db_name         = "search_db"

--- a/Infraestructura/terraform/stacks/database/database.secrets.tfvars
+++ b/Infraestructura/terraform/stacks/database/database.secrets.tfvars
@@ -2,11 +2,14 @@ db_username = "travelhub"
 db_password = "Grupo12.2026"
 
 service_db_passwords = {
-  authservice = "Grupo12.2026"
-  booking     = "Grupo12.2026"
-  catalog     = "Grupo12.2026"
-  payment     = "Grupo12.2026"
-  search      = "Grupo12.2026"
+  authservice          = "Grupo12.2026"
+  booking              = "Grupo12.2026"
+  catalog              = "Grupo12.2026"
+  payment              = "Grupo12.2026"
+  "pms-integration"    = "Grupo12.2026"
+  "partner-management" = "Grupo12.2026"
+  notification         = "Grupo12.2026"
+  search               = "Grupo12.2026"
 }
 
 payment_app_runtime_secrets = {


### PR DESCRIPTION
## Resumen

Completa el soporte de despliegue en AWS/EKS para los servicios migrados y el worker de saga, manteniendo los nombres y patrones existentes de infraestructura.

## Cambios

- Agrega repositorios ECR para:
  - `pms-integration`
  - `partner-management`
  - `notification`
- Agrega configuración RDS/Secrets Manager para:
  - `pms_integration_db`
  - `partner_management_db`
  - `notification_db`
- Conecta los deployments de EKS de `pms-integration`, `partner-management` y `notification` a sus respectivos DB secrets.
- Completa variables runtime de `booking` en EKS para DB postgres, catalog, payment y RabbitMQ.
- Agrega deployment de `booking-saga-worker` reutilizando la imagen de `booking`.
- Actualiza `backend-cd-prod.yml` para:
  - reconciliar DB secrets de los servicios migrados,
  - desplegar el worker de saga junto con `booking`,
  - esperar rollout del worker.

## Validación

- `terraform fmt -check -recursive Infraestructura\terraform`
- `terraform validate` en:
  - `container_registry`
  - `database`
  - `eks`
  - `ingress`
- `terraform plan` para `container_registry`:
  - `6 to add, 0 to change, 0 to destroy`
- `terraform plan` para `database`:
  - `18 to add, 0 to change, 0 to destroy`
- `kubectl apply --dry-run=client` para:
  - `booking-deployment.yaml`
  - `pms-integration-deployment.yaml`
  - `partner-management-deployment.yaml`
  - `notification-deployment.yaml`
  - `booking-saga-worker-deployment.yaml`

## Notas

Los planes de Terraform solo crean recursos nuevos; no reemplazan ni destruyen recursos existentes.
